### PR TITLE
Update SoundTriggerHalLegacy

### DIFF
--- a/services/soundtrigger/SoundTriggerHalLegacy.cpp
+++ b/services/soundtrigger/SoundTriggerHalLegacy.cpp
@@ -16,6 +16,7 @@
 
 #include <utils/Log.h>
 #include "SoundTriggerHalLegacy.h"
+#include <errno.h>
 
 namespace android {
 


### PR DESCRIPTION
fix error: use of undeclared identifier 'ENODEV'