### PR TITLE
audioflinger: Fix audio for WifiDisplay

### DIFF
--- a/services/audiopolicy/service/AudioPolicyInterfaceImpl.cpp
+++ b/services/audiopolicy/service/AudioPolicyInterfaceImpl.cpp
@@ -356,7 +356,7 @@ status_t AudioPolicyService::getInputForAttr(const audio_attributes_t *attr,
     }
 
     // check calling permissions
-    if (!recordingAllowed(opPackageName, pid, uid)) {
+    if (!isTrustedCallingUid(callingUid) && !recordingAllowed(opPackageName, pid, uid)) {
         ALOGE("%s permission denied: recording not allowed for uid %d pid %d",
                 __func__, uid, pid);
         return PERMISSION_DENIED;
@@ -500,7 +500,7 @@ status_t AudioPolicyService::startInput(audio_port_handle_t portId, bool *silenc
     }
 
     // check calling permissions
-    if (!startRecording(client->opPackageName, client->pid, client->uid)) {
+    if (!isTrustedCallingUid(IPCThreadState::self()->getCallingUid()) && !startRecording(client->opPackageName, client->pid, client->uid)) {
         ALOGE("%s permission denied: recording not allowed for uid %d pid %d",
                 __func__, client->uid, client->pid);
         return PERMISSION_DENIED;


### PR DESCRIPTION
AudioFlinger is not able to determine the correct
pid/tid for WifiDisplay and thus we do not pass checks
for CAPTURE_AUDIO_OUTPUT and RECORD_AUDIO permissions.

To fix audio for WifiDisplay, it should be safe to
always allow a trusted calling uid (AID_MEDIA which
has the same perms as AID_AUDIOSERVER).

Change-Id: Ifa46d8e77a43027645cad02a04263b58e134c3ae